### PR TITLE
Move backlog issue drafts into GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-wire-ai-studio-api.md
+++ b/.github/ISSUE_TEMPLATE/01-wire-ai-studio-api.md
@@ -1,0 +1,18 @@
+---
+name: "AI Studio: Wire hooks/captions/ideas/scripts to API"
+about: "Replace AI Studio mock data with real backend API calls."
+title: "Wire AI Studio (hooks, captions, ideas, scripts) to backend API"
+labels: ["enhancement", "ai", "frontend", "backend"]
+---
+
+## Description
+AI Studio page (`dashboard/ai`) currently uses mock data (`setTimeout`). Replace with real calls to existing backend endpoints using `api` and `endpoints.ai` so hooks, captions, ideas, and scripts are generated via OpenAI.
+
+## Acceptance Criteria
+- [ ] Replace mocked `setTimeout` data with API calls via `api` and `endpoints.ai`.
+- [ ] Hooks, captions, ideas, and scripts render from backend responses.
+- [ ] Loading/error states handled gracefully.
+- [ ] Remove any unused mock helpers once API integration is complete.
+
+## Notes
+- Confirm endpoint response shapes for each AI generation type before wiring UI.

--- a/.github/ISSUE_TEMPLATE/02-ai-generated-video-image-content.md
+++ b/.github/ISSUE_TEMPLATE/02-ai-generated-video-image-content.md
@@ -1,0 +1,18 @@
+---
+name: "AI Media: Generate video/image content"
+about: "Add AI-generated video and image content from prompts."
+title: "Add AI-generated video and image content"
+labels: ["enhancement", "ai", "media", "backend", "frontend"]
+---
+
+## Description
+Add the ability to generate video and/or image content with AI (e.g. DALL-E, or a video API) from prompts. Include backend endpoint(s), optional storage of generated assets, and UI in the post composer or AI Studio to trigger generation and attach to posts.
+
+## Acceptance Criteria
+- [ ] Backend endpoint(s) to request AI image/video generation from prompts.
+- [ ] Optional storage for generated assets (persist URLs/metadata).
+- [ ] UI entry point in post composer or AI Studio to generate and attach assets.
+- [ ] Audit/usage logging and error handling.
+
+## Notes
+- Evaluate providers (e.g. DALL-E for images, a video API for clips) for cost/latency.

--- a/.github/ISSUE_TEMPLATE/03-ai-generated-avatars.md
+++ b/.github/ISSUE_TEMPLATE/03-ai-generated-avatars.md
@@ -1,0 +1,15 @@
+---
+name: "AI Avatars: Generate profile/brand images"
+about: "Allow users to generate avatars via AI."
+title: "Add AI-generated avatars (profile/brand images)"
+labels: ["enhancement", "ai", "media", "backend", "frontend"]
+---
+
+## Description
+Allow users to generate avatar or brand images via AI (e.g. from a text prompt or style options). Include backend endpoint, storage of generated image, and UI to generate and optionally set as profile/brand avatar.
+
+## Acceptance Criteria
+- [ ] Backend endpoint to generate avatar/brand images from prompt/style inputs.
+- [ ] Storage of generated image asset and metadata.
+- [ ] UI to generate, preview, and set as profile/brand avatar.
+- [ ] Respect org/user scoping and permissions.

--- a/.github/ISSUE_TEMPLATE/04-cross-platform-analytics.md
+++ b/.github/ISSUE_TEMPLATE/04-cross-platform-analytics.md
@@ -1,0 +1,19 @@
+---
+name: "Analytics: Cross-platform API + UI"
+about: "Aggregate and display analytics from TikTok/Instagram."
+title: "Implement cross-platform analytics (API + UI data)"
+labels: ["enhancement", "analytics", "backend", "frontend"]
+---
+
+## Description
+Add backend analytics routes (e.g. overview, posts, accounts) that aggregate metrics from TikTok and Instagram (and any future platforms) using each platform’s APIs.
+
+Persist or cache metrics as needed (e.g. Firestore or cache layer).
+
+Wire the existing Analytics dashboard UI to these APIs so it shows real views, likes, comments, shares, followers, and engagement over time (replace placeholder “No data available” states).
+
+## Acceptance Criteria
+- [ ] New analytics endpoints (overview/posts/accounts) aggregate platform metrics.
+- [ ] Metrics are cached/persisted for performance and historical views.
+- [ ] Analytics UI consumes real data (no placeholder states).
+- [ ] Coverage for views/likes/comments/shares/followers/engagement.

--- a/.github/ISSUE_TEMPLATE/05-best-performing-content.md
+++ b/.github/ISSUE_TEMPLATE/05-best-performing-content.md
@@ -1,0 +1,16 @@
+---
+name: "Analytics: Identify best performing content"
+about: "Rank and surface top posts/platforms based on metrics."
+title: "Identify best performing videos, platforms, and content"
+labels: ["enhancement", "analytics", "frontend", "backend"]
+---
+
+## Description
+Use analytics data (from cross-platform analytics) to rank and surface best-performing posts, clips, and platforms (e.g. top posts by engagement, best platform for a given metric).
+
+Expose this in the UI (e.g. Analytics or a “Top content” section) with filters by platform, date range, and metric.
+
+## Acceptance Criteria
+- [ ] Ranking logic based on engagement and selected metrics.
+- [ ] UI surfaces top posts/clips/platforms with filters.
+- [ ] Metrics sourced from analytics endpoints.

--- a/.github/ISSUE_TEMPLATE/06-ai-strategy-suggestions.md
+++ b/.github/ISSUE_TEMPLATE/06-ai-strategy-suggestions.md
@@ -1,0 +1,16 @@
+---
+name: "AI Strategy: Suggestions from analytics"
+about: "Generate AI strategy suggestions from analytics data."
+title: "AI suggestions for strategy based on analytics"
+labels: ["enhancement", "ai", "analytics", "backend", "frontend"]
+---
+
+## Description
+Add an AI feature that consumes analytics results (best performers, trends, engagement by platform/content type) and suggests strategies (e.g. post more of X, try Y format, best time/platform).
+
+Include backend endpoint(s) and UI to view and optionally apply suggestions.
+
+## Acceptance Criteria
+- [ ] Backend endpoint to generate strategy suggestions from analytics context.
+- [ ] UI displays suggestions with optional actions/next steps.
+- [ ] Suggestions scoped to org/user data only.

--- a/.github/ISSUE_TEMPLATE/07-long-form-to-short-form.md
+++ b/.github/ISSUE_TEMPLATE/07-long-form-to-short-form.md
@@ -1,0 +1,18 @@
+---
+name: "AI: Long-form to short-form workflow"
+about: "Import long-form content and generate short-form clips/scripts."
+title: "Import long-form content and break into short-form for all platforms"
+labels: ["enhancement", "ai", "content", "backend", "frontend"]
+---
+
+## Description
+Allow users to import long-form content (e.g. blog post URL, pasted text, or uploaded transcript).
+
+Use AI to split it into short-form clips/scripts (e.g. hooks + 30–60s segments) suitable for TikTok/Reels.
+
+Optionally support one-click (or guided) creation of multiple scheduled posts from the generated clips across selected platforms.
+
+## Acceptance Criteria
+- [ ] Inputs: URL, pasted text, or transcript upload.
+- [ ] AI output: hooks + 30–60s segment suggestions.
+- [ ] Optional flow to schedule multiple posts across platforms.

--- a/.github/ISSUE_TEMPLATE/08-chatbot-user-data.md
+++ b/.github/ISSUE_TEMPLATE/08-chatbot-user-data.md
@@ -1,0 +1,19 @@
+---
+name: "AI: Chatbot with user data context"
+about: "Add a chatbot that answers questions using user data."
+title: "Built-in chatbot with access to user data for prioritization"
+labels: ["enhancement", "ai", "backend", "frontend"]
+---
+
+## Description
+Add a chatbot (e.g. in dashboard or sidebar) that can answer questions about the user’s accounts, posts, and analytics.
+
+Give the chatbot context from user data (organizations, connected accounts, post history, analytics) via a secure backend endpoint (e.g. RAG or structured context) so it can suggest what to prioritize (e.g. “Which account needs content?”, “What performed best this week?”).
+
+Ensure only the current user’s data is exposed and that usage is scoped per org if applicable.
+
+## Acceptance Criteria
+- [ ] Chat UI available in dashboard or sidebar.
+- [ ] Backend context endpoint secured per user/org.
+- [ ] Responses limited to user’s authorized data.
+- [ ] Guidance on prioritization included in responses.

--- a/.github/ISSUE_TEMPLATE/09-audio-selection-trending-audios.md
+++ b/.github/ISSUE_TEMPLATE/09-audio-selection-trending-audios.md
@@ -1,0 +1,18 @@
+---
+name: "Media: Audio selection + trending sounds"
+about: "Select audio for clips and surface trending audios per platform."
+title: "Select audio for clips and surface top trending audios per platform"
+labels: ["enhancement", "media", "frontend", "backend"]
+---
+
+## Description
+Allow users to select or search audio (e.g. music/sounds) when creating video clips or posts, using platform-specific APIs where available (e.g. TikTok Sound/Music, Instagram music).
+
+Add a “trending audios” (or “trending sounds”) feature per platform so users can discover and attach top trending audio to their content.
+
+Persist chosen audio metadata with the post where supported by the platform API.
+
+## Acceptance Criteria
+- [ ] Audio search/selection UI in clip/post creation.
+- [ ] Trending audios surfaced per platform.
+- [ ] Audio metadata persisted with posts where supported.


### PR DESCRIPTION
### Motivation
- Consolidate ad-hoc backlog markdown files into official GitHub issue templates so requests are created through the repository UI rather than stored as standalone `issues/` drafts.
- Make each backlog item actionable by providing front-matter (`name`, `about`, `title`, `labels`) plus a clear description and acceptance criteria.

### Description
- Deleted the legacy `issues/*.md` files and added corresponding templates under `.github/ISSUE_TEMPLATE/` (nine templates such as `01-wire-ai-studio-api.md` through `09-audio-selection-trending-audios.md`).
- Each new template includes YAML front-matter and a concise `## Description` plus `## Acceptance Criteria` to guide implementation and triage.
- One file was moved/renamed from `issues/8-chatbot-user-data.md` to `.github/ISSUE_TEMPLATE/08-chatbot-user-data.md` as part of the cleanup.
- Changes were staged and committed with a single commit summarizing the move into issue templates.

### Testing
- Verified repository state with `git status -sb` and staged changes with `git add -A` before creating the commit, and the `git commit` completed successfully (17 files changed, templates created and legacy files removed). 
- Inspected the contents of the created templates with a file listing and paged view to confirm YAML front-matter and acceptance criteria were included. 
- No automated test suite was run because this is a documentation/content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69838741dce48327839537a33a259ce5)