### PR TITLE
Fix 12 bugs from code review

### DIFF
--- a/backend/src/routes/media.ts
+++ b/backend/src/routes/media.ts
@@ -14,80 +14,69 @@ export async function mediaRoutes(fastify: FastifyInstance) {
     async (request, reply) => {
       const { orgId } = request.params;
 
-      try {
-        const data = await request.file();
+      const data = await request.file();
 
-        if (!data) {
-          throw createError("No file uploaded", 400);
-        }
-
-        const allowedMimeTypes = [
-          "image/jpeg",
-          "image/png",
-          "image/gif",
-          "image/webp",
-          "video/mp4",
-          "video/quicktime",
-          "video/webm",
-        ];
-
-        if (!allowedMimeTypes.includes(data.mimetype)) {
-          throw createError(
-            "Invalid file type. Allowed: JPEG, PNG, GIF, WebP, MP4, MOV, WebM",
-            400
-          );
-        }
-
-        const fileId = randomUUID();
-        const extension = data.filename.split(".").pop() || "";
-        const filename = `${orgId}/${fileId}.${extension}`;
-
-        const bucket = getStorage().bucket();
-        const file = bucket.file(filename);
-
-        // Read file buffer
-        const chunks: Buffer[] = [];
-        for await (const chunk of data.file) {
-          chunks.push(chunk);
-        }
-        const buffer = Buffer.concat(chunks);
-
-        // Upload to Firebase Storage
-        await file.save(buffer, {
-          metadata: {
-            contentType: data.mimetype,
-            metadata: {
-              uploadedBy: request.user!.uid,
-              orgId,
-            },
-          },
-        });
-
-        // Make file publicly accessible
-        await file.makePublic();
-
-        const publicUrl = `https://storage.googleapis.com/${bucket.name}/${filename}`;
-
-        return reply.send({
-          success: true,
-          data: {
-            id: fileId,
-            url: publicUrl,
-            type: data.mimetype.startsWith("image/") ? "image" : "video",
-            filename: data.filename,
-            size: buffer.length,
-          },
-        });
-      } catch (error) {
-        if ((error as { statusCode?: number }).statusCode) {
-          throw error;
-        }
-        request.log.error(error, "Error uploading media");
-        return reply.status(500).send({
-          success: false,
-          error: "Failed to upload media",
-        });
+      if (!data) {
+        throw createError("No file uploaded", 400);
       }
+
+      const allowedMimeTypes = [
+        "image/jpeg",
+        "image/png",
+        "image/gif",
+        "image/webp",
+        "video/mp4",
+        "video/quicktime",
+        "video/webm",
+      ];
+
+      if (!allowedMimeTypes.includes(data.mimetype)) {
+        throw createError(
+          "Invalid file type. Allowed: JPEG, PNG, GIF, WebP, MP4, MOV, WebM",
+          400
+        );
+      }
+
+      const fileId = randomUUID();
+      const extension = data.filename.split(".").pop() || "";
+      const filename = `${orgId}/${fileId}.${extension}`;
+
+      const bucket = getStorage().bucket();
+      const file = bucket.file(filename);
+
+      // Read file buffer
+      const chunks: Buffer[] = [];
+      for await (const chunk of data.file) {
+        chunks.push(chunk);
+      }
+      const buffer = Buffer.concat(chunks);
+
+      // Upload to Firebase Storage
+      await file.save(buffer, {
+        metadata: {
+          contentType: data.mimetype,
+          metadata: {
+            uploadedBy: request.user!.uid,
+            orgId,
+          },
+        },
+      });
+
+      // Make file publicly accessible
+      await file.makePublic();
+
+      const publicUrl = `https://storage.googleapis.com/${bucket.name}/${filename}`;
+
+      return reply.send({
+        success: true,
+        data: {
+          id: fileId,
+          url: publicUrl,
+          type: data.mimetype.startsWith("image/") ? "image" : "video",
+          filename: data.filename,
+          size: buffer.length,
+        },
+      });
     }
   );
 
@@ -100,35 +89,24 @@ export async function mediaRoutes(fastify: FastifyInstance) {
     async (request, reply) => {
       const { orgId, mediaId } = request.params;
 
-      try {
-        const bucket = getStorage().bucket();
+      const bucket = getStorage().bucket();
 
-        // List files with the mediaId prefix in the org folder
-        const [files] = await bucket.getFiles({
-          prefix: `${orgId}/${mediaId}`,
-        });
+      // List files with the mediaId prefix in the org folder
+      const [files] = await bucket.getFiles({
+        prefix: `${orgId}/${mediaId}`,
+      });
 
-        if (files.length === 0) {
-          throw createError("Media not found", 404);
-        }
-
-        // Delete all matching files
-        await Promise.all(files.map((file) => file.delete()));
-
-        return reply.send({
-          success: true,
-          message: "Media deleted successfully",
-        });
-      } catch (error) {
-        if ((error as { statusCode?: number }).statusCode) {
-          throw error;
-        }
-        request.log.error(error, "Error deleting media");
-        return reply.status(500).send({
-          success: false,
-          error: "Failed to delete media",
-        });
+      if (files.length === 0) {
+        throw createError("Media not found", 404);
       }
+
+      // Delete all matching files
+      await Promise.all(files.map((file) => file.delete()));
+
+      return reply.send({
+        success: true,
+        message: "Media deleted successfully",
+      });
     }
   );
 }

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -18,6 +18,7 @@ export interface Organization {
   name: string;
   ownerId: string;
   members: OrganizationMember[];
+  memberUserIds: string[];
   createdAt: Timestamp;
 }
 

--- a/frontend/src/app/(dashboard)/dashboard/analytics/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/analytics/page.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/dashboard/header";
 import { useOrganization } from "@/lib/hooks";
 import { api, endpoints } from "@/lib/api";
 import { Post, SocialAccount } from "@/types";
+import { toast } from "sonner";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -35,6 +36,7 @@ export default function AnalyticsPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    let cancelled = false;
     const fetchData = async () => {
       if (!currentOrganization) return;
       try {
@@ -46,15 +48,18 @@ export default function AnalyticsPage() {
             endpoints.accounts.list(currentOrganization.id)
           ),
         ]);
+        if (cancelled) return;
         setPosts(postsRes.data ?? []);
         setAccounts(accountsRes.data ?? []);
       } catch (error) {
         console.error("Failed to fetch analytics data:", error);
+        if (!cancelled) toast.error("Failed to load analytics data");
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
     fetchData();
+    return () => { cancelled = true; };
   }, [currentOrganization]);
 
   const totalPosts = posts.length;

--- a/frontend/src/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/src/app/(dashboard)/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/dashboard/header";
 import { useOrganization } from "@/lib/hooks";
 import { api, endpoints } from "@/lib/api";
 import { Post, SocialAccount } from "@/types";
+import { toast } from "sonner";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -36,6 +37,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    let cancelled = false;
     const fetchData = async () => {
       if (!currentOrganization) return;
       try {
@@ -47,15 +49,18 @@ export default function DashboardPage() {
             endpoints.accounts.list(currentOrganization.id)
           ),
         ]);
+        if (cancelled) return;
         setPosts(postsRes.data ?? []);
         setAccounts(accountsRes.data ?? []);
       } catch (error) {
         console.error("Failed to fetch dashboard data:", error);
+        if (!cancelled) toast.error("Failed to load dashboard data");
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
     };
     fetchData();
+    return () => { cancelled = true; };
   }, [currentOrganization]);
 
   const totalPosts = posts.length;


### PR DESCRIPTION
## Summary
- **Org delete orphans jobs**: Delete handler now cleans up `scheduledJobs` for the org
- **Post update ignores job lifecycle**: Update handler creates/updates/deletes scheduled jobs when `scheduledAt` changes
- **Org member query broken**: Replaced `array-contains-any` with objects (never matches due to `joinedAt` field) with flat `memberUserIds` array + `array-contains`
- **media.ts leftover try-catch**: Removed manual try-catch blocks, errors bubble to centralized handler
- **Raw Timestamps in post responses**: Added `serializeTimestamps()` helper converting Firestore Timestamps to ISO strings
- **OAuth CSRF**: Added HMAC signing/verification to OAuth state parameter using `timingSafeEqual`
- **Form validation bypass**: Added `form.trigger()` before `getValues()` in post creation handlers
- **Race conditions**: Added `cancelled` flag cleanup in async useEffects across 4 pages
- **Blob URL memory leak**: Added ref-based cleanup on unmount for media previews
- **Draft auto-selects account**: Replaced silent first-account fallback with explicit validation
- **Posts show account IDs**: Fetches accounts and maps IDs to `@username` display
- **Silent fetch failures**: Added `toast.error()` on data fetch failures in dashboard, analytics, posts pages

## Test plan
- [ ] Delete an org → verify no orphaned scheduled jobs remain in Firestore
- [ ] Update a post's `scheduledAt` → verify corresponding job is created/updated/removed
- [ ] List orgs as a member → verify query returns correct results
- [ ] Upload/delete media → verify errors are caught by centralized handler
- [ ] Fetch posts via API → verify timestamps are ISO strings, not `{_seconds, _nanoseconds}`
- [ ] OAuth connect flow → verify state has HMAC signature, callback rejects tampered state
- [ ] Create post with >2200 chars → verify validation error shown before submission
- [ ] Switch orgs rapidly → verify no stale data from previous org appears
- [ ] Add media previews, navigate away → verify no blob URL leak warnings
- [ ] Save draft without selecting account → verify "Please select at least one account" toast
- [ ] View posts list → verify `@username` badges instead of raw account IDs
- [ ] Disconnect network, load dashboard → verify error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)